### PR TITLE
add option for iTerm2 nightly builds on Yosemite

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ Just type MacTerminal
     }
     ```
 
+    or (for compatibility with the nightly builds of iTerm 2 on Yosemite):
+    ```
+    {
+        "terminal"   :  "iterm-nightly"
+    }
+    ```
+
     If you wish you can also change it in Settings - Default.
 
 5. How do I change path to ``` osascript ``` ?

--- a/macterminal_iterm-nightly.js
+++ b/macterminal_iterm-nightly.js
@@ -1,0 +1,23 @@
+/* global Application, delay */
+
+function run(argv) {
+
+    if (argv.length === 0) {
+        console.log("missing path");
+        return;
+    }
+
+    var Terminal = Application('iTerm');
+    var SystemEvents = Application('System Events');
+
+    SystemEvents.keystroke(
+        "t",
+        {using: "command down"}
+    );
+
+    var gotoDirectory = 'cd ' + argv.join(' ');
+    var currentTerminalSession = Terminal.currentWindow.currentSession;
+    currentTerminalSession.write({text: gotoDirectory});
+    currentTerminalSession.write({text: 'clear'});
+    Terminal.activate();
+}


### PR DESCRIPTION
Quick little addition for people running the nightly builds of iTerm2 (minor applescript changes) on Yosemite - they can set the option:

```
"terminal"   :  "iterm-nightly"
```