### PR TITLE
Fix up iTerm2 scripting changes that came in 2.9.20150414.

### DIFF
--- a/macterminal_iterm.js
+++ b/macterminal_iterm.js
@@ -21,7 +21,14 @@ function run(argv) {
     );
 
     var gotoDirectory = 'cd ' + argv.join(' ');
-    var currentTerminalSession = Terminal.currentTerminal().currentSession();
+    if (parseInt(Terminal.version().replace(/\./g,'')) >= 2920150414) {
+        // Current iTerm2 - 2.9.20150414 or later 
+        var currentTerminalSession = Terminal.currentWindow.currentSession;
+    }
+    else {
+        // Old iTerm2 - Prior to 2.9.20150414 
+        var currentTerminalSession = Terminal.currentTerminal().currentSession();
+    }
     currentTerminalSession.write({text: gotoDirectory});
     currentTerminalSession.write({text: 'clear'});
 }


### PR DESCRIPTION
Something to consider.  It seems iTerm2 had some scripting changes at 2.9.20150414, you can read about it here:

https://iterm2.com/applescript.html

So the new beta (which is very nice :+1: ) was failing for me.  This patch fixed it up.

Thanks...