### PR TITLE
fix Decimal error when mac_ver() is 10.10.x

### DIFF
--- a/open_mac_terminal.py
+++ b/open_mac_terminal.py
@@ -161,7 +161,7 @@ class OpenMacTerminal(sublime_plugin.TextCommand):
         # get osascript from settings or just use default value
         command.append(self.settings.get('osascript', '/usr/bin/osascript'))
 
-        if Decimal(platform.mac_ver()[0]) >= Decimal('10.10'):
+        if Decimal(".".join(platform.mac_ver()[0].split(".")[:2])) >= Decimal('10.10'):
             ext_language = 'js'
         else:
             ext_language = 'scpt'


### PR DESCRIPTION
I just found the following error and fixed it with this pull request.

In line 164 of open_mac_terminal.py, when the "platform.mac_ver()[0]" returns 10.10.4, the "Decimal()" will fail to parse it. The full log is in the following:

%%%%%%%%
Traceback (most recent call last):
  File "/Applications/Sublime Text.app/Contents/MacOS/sublime_plugin.py", line 556, in run_
    return self.run(edit)
  File "/Users/junyang.shen/Library/Application Support/Sublime Text 3/Packages/MacTerminal/open_mac_terminal.py", line 113, in run
    self.open_terminal()
  File "/Users/junyang.shen/Library/Application Support/Sublime Text 3/Packages/MacTerminal/open_mac_terminal.py", line 128, in open_terminal
    self.open_terminal_command(self.paths[0])
  File "/Users/junyang.shen/Library/Application Support/Sublime Text 3/Packages/MacTerminal/open_mac_terminal.py", line 164, in open_terminal_command
    if Decimal(platform.mac_ver()[0]) >= Decimal('10.10'):
  File "./decimal.py", line 589, in __new__
  File "./decimal.py", line 4044, in _raise_error
decimal.InvalidOperation: Invalid literal for Decimal: '10.10.4'
%%%%%%%%%
